### PR TITLE
Transparent qr background

### DIFF
--- a/qr_script.py
+++ b/qr_script.py
@@ -7,42 +7,9 @@ import PIL
 import base64
 import sys
 
-def email2qr(event, context):
-    """
-    The event is expected to have an email
-    and optionally a color and a background (color)
-    (both being 3-tuples of RGB values).
-    It also takes optional parameters fgOpacity and bgOpacity,
-    which set the foreground and background opacity, respectively.
-    It can also take a boolean transparentBackground which, if true,
-    overrides bgOpacity and makes the background fully transparent.
-    Provided this, the function returns the base-64
-    encoded QR code for the email in color passed in
-    as 'color' and background color passed as 'background'.
-    """
-
-    # We default to a black on white QR
-    # and full opacity in both the foreground and background.
-    color = event.get('color', [0x0,0x0,0x0])
-    background = event.get('background', [0xff,0xff,0xff])
-    fgOpacity = event.get('fgOpacity', 0xff)
-    bgOpacity = event.get('bgOpacity', 0xff)
-    bgOpacity = 0x0 if event.get('transparentBackground') else bgOpacity
-
-    #email must be provided
-    if 'email' not in event:
-        return config.add_cors_headers({'statusCode':400, 'body':'Invalid request format.'})
-
-    email = event['email']
-    pilImg = qrcode.make(email)
-    #We take the bitmap and put the foreground color if the bit is 0
-    #and the background otherwise.
-    r = pilImg.point(lambda x: color[0] if x == 0 else background[0], mode='L')
-    g = pilImg.point(lambda x: color[1] if x == 0 else background[1], mode='L')
-    b = pilImg.point(lambda x: color[2] if x == 0 else background[2], mode='L')
-    a = pilImg.point(lambda x: fgOpacity if x == 0 else bgOpacity, mode='L')
-    #we merge the RGB processed as above.
-    img = PIL.Image.merge('RGBA', (r,g,b,a))
+def email2qr(email):
+    #construct the QR code
+    img = qrcode.make(email)
     #save as a byte array
     byteArr = io.BytesIO()
     img.save(byteArr, format='PNG')
@@ -53,12 +20,4 @@ def email2qr(event, context):
 
 if __name__ == '__main__':
     email = sys.argv[1] if len(sys.argv) >= 2 else 'test@example.com'
-    event = {
-            'email': email,
-            'color': [0x0,0x0,0x0],
-            'background': [0xff,0xff,0xff],
-            #'fgOpacity': 0xff,
-            #'bgOpacity': 0xff,
-            #'transparentBackground': False
-            }
-    print(email2qr(event, None))
+    print(email2qr(email))

--- a/qr_script.py
+++ b/qr_script.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python
+# run with `chromium $(python qr_script.py test@example.com)`
+
+import io
+import qrcode
+import PIL
+import base64
+import sys
+
+def email2qr(event, context):
+    """
+    The event is expected to have an email
+    and optionally a color and a background (color)
+    (both being 3-tuples of RGB values).
+    It also takes optional parameters fgOpacity and bgOpacity,
+    which set the foreground and background opacity, respectively.
+    It can also take a boolean transparentBackground which, if true,
+    overrides bgOpacity and makes the background fully transparent.
+    Provided this, the function returns the base-64
+    encoded QR code for the email in color passed in
+    as 'color' and background color passed as 'background'.
+    """
+
+    # We default to a black on white QR
+    # and full opacity in both the foreground and background.
+    color = event.get('color', [0x0,0x0,0x0])
+    background = event.get('background', [0xff,0xff,0xff])
+    fgOpacity = event.get('fgOpacity', 0xff)
+    bgOpacity = event.get('bgOpacity', 0xff)
+    bgOpacity = 0x0 if event.get('transparentBackground') else bgOpacity
+
+    #email must be provided
+    if 'email' not in event:
+        return config.add_cors_headers({'statusCode':400, 'body':'Invalid request format.'})
+
+    email = event['email']
+    pilImg = qrcode.make(email)
+    #We take the bitmap and put the foreground color if the bit is 0
+    #and the background otherwise.
+    r = pilImg.point(lambda x: color[0] if x == 0 else background[0], mode='L')
+    g = pilImg.point(lambda x: color[1] if x == 0 else background[1], mode='L')
+    b = pilImg.point(lambda x: color[2] if x == 0 else background[2], mode='L')
+    a = pilImg.point(lambda x: fgOpacity if x == 0 else bgOpacity, mode='L')
+    #we merge the RGB processed as above.
+    img = PIL.Image.merge('RGBA', (r,g,b,a))
+    #save as a byte array
+    byteArr = io.BytesIO()
+    img.save(byteArr, format='PNG')
+    byteImg = byteArr.getvalue()
+    #then read and encode.
+    encodedImg = base64.standard_b64encode(byteImg)
+    return 'data:image/png;base64,' + encodedImg.decode()
+
+if __name__ == '__main__':
+    email = sys.argv[1] if len(sys.argv) >= 2 else 'test@example.com'
+    event = {
+            'email': email,
+            'color': [0x0,0x0,0x0],
+            'background': [0xff,0xff,0xff],
+            #'fgOpacity': 0xff,
+            #'bgOpacity': 0xff,
+            #'transparentBackground': False
+            }
+    print(email2qr(event, None))

--- a/qr_script.sh
+++ b/qr_script.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# run with `chromium $(./qr_script.sh test@example.com)`
+email='test@example.com'
+if test $# -ge 1
+then
+	email=$1
+fi
+curl -H "content-type: application/json" -d "{\"email\": \"$email\", \"color\": [0,0,0], \"background\": [255,255,255]}" https://m7cwj1fy7c.execute-api.us-west-2.amazonaws.com/test/qr | grep -o 'data.*",' | sed 's/..$//'

--- a/qru.py
+++ b/qru.py
@@ -9,14 +9,22 @@ def email2qr(event, context):
     The event is expected to have an email
     and optionally a color and a background (color)
     (both being 3-tuples of RGB values).
+    It also takes optional parameters fgOpacity and bgOpacity,
+    which set the foreground and background opacity, respectively.
+    It can also take a boolean transparentBackground which, if true,
+    overrides bgOpacity and makes the background fully transparent.
     Provided this, the function returns the base-64
     encoded QR code for the email in color passed in
     as 'color' and background color passed as 'background'.
     """
 
-    #We default to a black on white QR.
+    # We default to a black on white QR
+    # and full opacity in both the foreground and background.
     color = event.get('color', [0x0,0x0,0x0])
     background = event.get('background', [0xff,0xff,0xff])
+    fgOpacity = event.get('fgOpacity', 0xff)
+    bgOpacity = event.get('bgOpacity', 0xff)
+    bgOpacity = 0x0 if event.get('transparentBackground') else bgOpacity
 
     #email must be provided
     if 'email' not in event:
@@ -29,8 +37,9 @@ def email2qr(event, context):
     r = pilImg.point(lambda x: color[0] if x == 0 else background[0], mode='L')
     g = pilImg.point(lambda x: color[1] if x == 0 else background[1], mode='L')
     b = pilImg.point(lambda x: color[2] if x == 0 else background[2], mode='L')
+    a = pilImg.point(lambda x: fgOpacity if x == 0 else bgOpacity, mode='L')
     #we merge the RGB processed as above.
-    img = PIL.Image.merge('RGB', (r,g,b))
+    img = PIL.Image.merge('RGBA', (r,g,b,a))
     #save as a byte array
     byteArr = io.BytesIO()
     img.save(byteArr, format='PNG')


### PR DESCRIPTION
Two quick QR things: transparent QRs allowed (optionally - default is opaque)
and Qr creation scripts in case of bad WiFi.