### PR TITLE
Tweaks to deploy

### DIFF
--- a/consume.py
+++ b/consume.py
@@ -13,7 +13,7 @@ def updateUserFromMagicLink(userCollection,maglinkobj,event):
     #if the user forgot, then read the password and change it
     if maglinkobj['forgot'] == True:
         pass_ = event['password']
-        pass_ = bcrypt.hashpw(password.encode('utf-8'), bcrypt.gensalt())
+        pass_ = bcrypt.hashpw(pass_.encode('utf-8'), bcrypt.gensalt())
         checkifmlh = userCollection.find_one({"email":maglinkobj['email']})
         if checkifmlh and checkifmlh['mlh']:
             return config.add_cors_headers({

--- a/consume.py
+++ b/consume.py
@@ -4,7 +4,7 @@ import validate
 import config 
 import string
 from datetime import datetime, timedelta
-import hashlib
+import bcrypt
 
 def updateUserFromMagicLink(userCollection,maglinkobj,event):
     """
@@ -13,7 +13,7 @@ def updateUserFromMagicLink(userCollection,maglinkobj,event):
     #if the user forgot, then read the password and change it
     if maglinkobj['forgot'] == True:
         pass_ = event['password']
-        pass_ = hashlib.md5(pass_.encode('utf-8') ).hexdigest() 
+        pass_ = bcrypt.hashpw(password.encode('utf-8'), bcrypt.gensalt())
         checkifmlh = userCollection.find_one({"email":maglinkobj['email']})
         if checkifmlh and checkifmlh['mlh']:
             return config.add_cors_headers({

--- a/deploy.sh
+++ b/deploy.sh
@@ -4,7 +4,7 @@ pip install -r requirements.txt
 mkdir deploy/
 
 if [ -d "venv/lib/python3.6" ]; then
-    cp -r venv/lib/python3.6/site-packages/* deploy/
+    cp -r venv/lib/python3.6/site-packages/. deploy/
 else
     cp -r venv/lib/python3.5/site-packages/* deploy/
 fi
@@ -15,7 +15,7 @@ do
 done
 cp config.py deploy/
 cd deploy/
-zip -r dep.zip *
+zip -r dep.zip .
 cd ..
 cp deploy/dep.zip .
 rm -rf deploy/

--- a/deploy.sh
+++ b/deploy.sh
@@ -4,9 +4,9 @@ pip install -r requirements.txt
 mkdir deploy/
 
 if [ -d "venv/lib/python3.6" ]; then
-    cp -r venv/lib/python3.6/site-packages/ deploy/
+    cp -r venv/lib/python3.6/site-packages/* deploy/
 else
-    cp -r venv/lib/python3.5/site-packages/ deploy/
+    cp -r venv/lib/python3.5/site-packages/* deploy/
 fi
 
 for var in "$@"

--- a/read.py
+++ b/read.py
@@ -62,5 +62,6 @@ def read_info(event, context):
     if not event['aggregate']:
         for i in res_:
             del i['_id']
+            del i['password']
 
     return config.add_cors_headers({"statusCode": 200, "body": res_})


### PR DESCRIPTION
A few quick changes as a result of bcrypt (heck, we need moar coverage):
 - Read can't send bytes, but our hashes are bytes.
 - Consume should use the new hash.
 - Deploy script should now work.